### PR TITLE
add basic Docker-Coq-Action opam-based CI for Coq master

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -1,0 +1,30 @@
+name: Docker CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  build:
+    # the OS must be GNU/Linux to be able to use the docker-coq-action
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - 'coqorg/coq:dev'
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - uses: coq-community/docker-coq-action@v1
+        with:
+          opam_file: 'coq-coinduction.opam'
+          custom_image: ${{ matrix.image }}
+
+
+# See also:
+# https://github.com/coq-community/docker-coq-action#readme
+# https://github.com/erikmd/docker-coq-github-action-demo

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Coinduction
 
+[![Docker CI][docker-action-shield]][docker-action-link]
+[docker-action-shield]: https://github.com/damien-pous/coinduction/workflows/Docker%20CI/badge.svg?branch=master
+[docker-action-link]: https://github.com/damien-pous/coinduction/actions?query=workflow:"Docker%20CI"
+
 A library for doing proofs by (enhanced) coinduction.
 
 It is based on the notion of 'companion' from the paper


### PR DESCRIPTION
Includes a small badge in README.md that shows CI status.