### PR TITLE
add gfp_bchain utility lemma to tower

### DIFF
--- a/theories/tower.v
+++ b/theories/tower.v
@@ -112,7 +112,11 @@ Section s.
    intros f Hf. revert x. apply (tower (inf_closed_leq _)). 
    intros x fx. rewrite (Hf x). now apply b. 
  Qed.
- 
+
+ (** an instance of [gfp_chain] which is useful in some concrete use cases *)
+ Lemma gfp_bchain (x: Chain): gfp <= b x.
+ Proof. apply gfp_chain. Qed.
+
 End s.
 Global Opaque gfp. 
   


### PR DESCRIPTION
Here is a small utility lemma originally by @YaZko that made some coinduction arguments on possibly-infinite lists a lot [easier](https://github.com/palmskog/negative-traces/commit/a2f65af09ae96845a4d7a0a2f407d81769a8bdf4). Hopefully worth including, and I think this is the right place.