### PR TITLE
adapt opam and ci for 8.16 to 8.18 compatibility

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -3,7 +3,6 @@ name: Docker CI
 on:
   push:
     branches:
-      - master
       - 8.18
   pull_request:
     branches:
@@ -16,8 +15,9 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'coqorg/coq:dev'
           - 'coqorg/coq:8.18'
+          - 'coqorg/coq:8.17'
+          - 'coqorg/coq:8.16'
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/coq-coinduction.opam
+++ b/coq-coinduction.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "damien.pous@ens-lyon.fr"
-version: "dev"
+version: "8.18.dev"
 
 homepage: "https://github.com/damien-pous/coinduction"
 dev-repo: "git+https://github.com/damien-pous/coinduction.git"
@@ -19,7 +19,7 @@ build: [
 ]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.16.1")}
+  "coq" {>= "8.16.1" & < "8.19~"}
 ]
 
 tags: [


### PR DESCRIPTION
Note that this PR is against the `8.18` branch, and that that branch can't be compatible with Coq `master` due to changes in Coq.