### PR TITLE
fix ci and opam for Coq master

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - 8.18
   pull_request:
     branches:
       - '**'
@@ -17,7 +16,6 @@ jobs:
       matrix:
         image:
           - 'coqorg/coq:dev'
-          - 'coqorg/coq:8.18'
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/coq-coinduction.opam
+++ b/coq-coinduction.opam
@@ -19,7 +19,7 @@ build: [
 ]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.16.1")}
+  "coq" {>= "8.19"}
 ]
 
 tags: [

--- a/src/reification.ml
+++ b/src/reification.ml
@@ -224,7 +224,7 @@ let apply rname mode goal =
         we do so in OCaml rather than in Ltac: this makes it possible to avoid the mess with de Bruijn indices *)
      (* debug (Cnd.ptower a b cs c x); *)
      (* debug g; *)
-     tclTHEN (Tactics.revert [rname])
+     tclTHEN (Generalize.revert [rname])
        (tclTHEN (typecheck_and_apply (Cnd.ptower a b cs c x))
           (tclTHEN (Tactics.introduction rname)
              (Tactics.convert_concl ~cast:false ~check:true g DEFAULTcast)


### PR DESCRIPTION
Some recent changes look to have broken compatibility with Coq `master` for the `master` branch here. This PR fixes this and updates ci and opam. We can't be compatible with 8.18 and earlier anymore due to Coq changes.